### PR TITLE
async: separate cancelation from exceptions

### DIFF
--- a/std/async/async.kk
+++ b/std/async/async.kk
@@ -31,19 +31,237 @@ import std/num/ddouble    // for C# backend
 import std/time/duration
 import std/async/null
 import std/core/unsafe
+import std/core/undiv
 pub import std/num/ddouble
 pub import std/num/float64
 import std/time/timestamp
+import std/core-extras
 
-  // js is just using primitives
+/*
+# Cancellation scopes
 
-// A type alias for asynchronous operations that can raise exceptions non-deterministically.
-// This is common for almost all `:async` operations since `cancel` and `timeout` can
-// cancel operations non-deterministically which raises the `Cancel` exception and cancels
-// outstanding asynchronous requests.
-pub alias asyncx = <async,exn,ndet>
+Each scope has a unique ID (int).
 
-pub alias async-exn = <async,exn>
+When we await any async action, we associate it with its full scope chain. If
+scope a spawns scope b which spawns scope c which spawns an action, that
+action's scope is Scope([c, b, a]) - a scope is just a list of scope IDs,
+childmost first.
+
+When we decide to cancel a scope, we cancel it by ID, e.g. `b`. This will
+cancel the following scopes:
+
+`[b, _]` -> clearly in b `[_, b, _])` -> a child scope of b
+
+It will not cancel something in `[a, d]` (i.e. within `a` but not `b`)
+
+# Cancelation: up and down
+
+When cancelation is triggered, it is generally triggered from _within_ the
+scope to be canceled, and affects all transitive child scopes. There are many
+reasons for cancelation:
+ - returning normally, cancelation prevents dangling callbacks
+ - returning abnormally (e.g. exn), we cancel any pending callbacks
+ - within a `firstof`, we have decided to cancel all remaining strands after
+   the first is complete
+
+After cancelation is triggered, the canceler's execution continues as normal -
+calling `cancel-scope` simply returns `()`.
+
+Triggering affects actions within the scope - so when observing cancelation, it
+being triggered from somewhere "up" the stack. It's like a reverse of an
+exception (which is coming from "down" the stack and observed "up" the stack).
+
+The way that cancelation is observed is that all outstanding callbacks beneath
+the canceled scope receive a `Cancel` instead of a `Result`. Aside from
+low-level code, you won't observe this - the higher level utilities for
+awaiting a result will automatically invoke `discontinue()` on the execution
+which is awaiting the result.
+
+It's not intended to be possible to "catch" a `discontinue` - cancelation can
+be deferred to protect some critical section (using `defer-cancelation`), but
+that only means cancelation will take effect at the end of that critical
+section - it cannot be stopped.
+
+(Internally `interleave` does "catch" cancelation, but it's a special case and
+is careful to maintain these semantics)
+
+# Strands (interleave)
+
+Multiple strands can be cooperatively executed, by running each in a custom
+`async` handler. Instead of awaiting a result, the handler returns immediately
+and the callback triggers an enqueue onto an internal channel.
+
+Continuations are consumed from this channel until all strands have completed.
+
+When one strand returns abnormally (e.g. exception), the entire scope is
+canceled. This will cause any pending callbacks to be resolved with a Cancel
+result.
+
+# Interleave and cancelation
+
+In order to control cancelation explicitly, `interleave-strands` creates a root
+scope instead of a child scope to spawn operations in. No actions spawned
+within this scope will be seen as children of the parent scope, preventing
+automatic cancelation when a parent scope is canceled.
+
+Instead, `interleave-strands` _observes_ when the parent scope is canceled, and
+triggers cancelation on the child strands. Crucially this doesn't cancel the
+interleaving bookkeeping itself, which ensures that:
+ - `interleave-raw` always observes the final states of all strands, even if
+   all of them are `Cancel`
+ - We drive each strand to completion, including finalizers. If we simply
+   abandoned the bookeeping, we'd potentially leave finalize actions sitting in
+   an unconsumed channel instead of running them.
+
+*/
+
+// Asynchronous operations have the `:async` effect.
+// **Note**: technically, async is capable of embedding arbitrary `io-noexn`
+// actions, as this is typically required to interface with the event loop.
+//
+// Code which makes use of this low-level capability should take care to
+// represent the appropriate semantic effects in addition to `async`.
+pub effect async
+  val async-scope: scope
+
+  // setup a callback and await its completion
+  ctl do-await( setup : await-setup<a>, scope : scope) : await-result<a>
+  
+  // setup a callback to execute `f` on completion, returning control to the caller immediately
+  // after the setup is performed
+  ctl no-await( setup : await-setup<a>, scope : scope, f : await-result<a> -> io-noexn ()  ) : ()
+
+  // Internal: evaluate io in async
+  ctl async-iox( action : () -> io-noexn a ) : a
+
+  // trigger cancelation of a specific scope (and all its children)
+  ctl cancel-scope( scope : scope-id ) : ()
+
+  // React to cancelation of this expression
+  final ctl discontinue(): a
+
+// A type alias for asynchronous operations which are both `ndet` and `div` (may never return).
+// This is common for almost all `:async` operations due to concurrency and cancelation.
+// TODO: remove st<global> from this alias
+pub alias asyncx = <async,ndet,div,st<global>>
+
+pub alias async-exn = <asyncx,exn>
+
+pub fun on-cancel(fin: () -> <async|e> (), action: () -> <async|e> a): <async|e> a
+  handle<async>({ mask behind<async>(action) })
+    final ctl discontinue()
+      fin()
+      discontinue()
+
+    // passthrough others
+    val async-scope = async-scope
+    fun do-await(setup, scope) do-await(setup,scope)
+    fun no-await(setup, scope, f) no-await(setup,scope, f)
+    fun async-iox(x) async-iox(x)
+    fun cancel-scope(scope) cancel-scope(scope)
+
+// ----------------------------------------------------------------------------
+// Async effect
+// ----------------------------------------------------------------------------
+pub type await-result<a>
+  Cancel
+  Result(value: a)
+
+fun await-result/show(r: await-result<a>)
+  match r
+    Cancel -> "Cancel"
+    Result(_) -> "Result(_)"
+
+type strand-result<a>
+  Finalize(y: yield-info)
+  Complete(value: a)
+  
+fun strand-result/show(s: strand-result<a>)
+  match s
+    Finalize(_) -> "Finalize(...)"
+    Complete(_) -> "Complete(_)"
+
+fun continue-await(v: await-result<a>): asyncx a
+  match v
+    Result(value) -> value
+    Cancel -> discontinue()
+
+fun continue-strand(v: strand-result<a>): total a
+  match v
+    Complete(value) -> value
+    Finalize(yield-info) -> unsafe-reyield(yield-info)
+
+fun finalize-strand(v: strand-result<a>): total ()
+  match v
+    Complete(_) -> ()
+    Finalize(yield-info) -> unsafe-reyield(yield-info)
+
+alias maybe-dispose-fn = (maybe<() -> io-noexn ()>)
+
+alias await-setup<a> = (cb : (await-result<a>, bool) -> io-noexn ()) -> io-noexn maybe-dispose-fn
+
+// Prevents cancelation, but invokes a hook immediately for notification
+fun unsafe-override-cancel(on-cancel-hook: () -> <io-noexn> (), action: () -> <asyncx|e> a): <asyncx|e> a
+  val dangling-cb: ref<global,_> = ref(Nothing)
+  with finally {
+    // ensure dangling-cb gets invoked so we don't leak uninvoked and uncancelled callbacks
+    match !dangling-cb
+      Just(cb) -> async-iox { cb(Result(()), True) }
+      Nothing -> ()
+  }
+
+  // within the outer scope, spawn a canary action
+  // to capture cancelation triggered from above.
+  fun setup-cb(cb: ((await-result<()>, bool) -> io-noexn ())): io-noexn maybe-dispose-fn
+    dangling-cb.set(Just(cb))
+    return Just(on-cancel-hook) // cleanup fn
+  no-await(setup-cb, async-scope, fn(_) ())
+
+  // create a new scope root, so that any callbacks registered
+  // underneath this scope will not be seen as children of
+  // any scopes above us (and therefore not canceled if an outer
+  // scope is canceled)
+  val cid = async-iox { unique() }
+  val new-scope = empty-scope.child(cid)
+
+  with finally {
+    cancel-scope(cid) // don't leave anything dangling in case of exn etc
+  }
+
+  with handler<async>
+    val async-scope = new-scope
+    fun do-await(setup,scope) do-await(setup,scope)
+    fun no-await(setup,scope,f) no-await(setup,scope,f)
+
+    // We notice cancelation from a parent via the canary. We also
+    // need to modify the `cancel-scope` hook so that we notice (and defer)
+    // cancelation triggered from within this scope, but only if it's
+    // targeted at exactly this scope.
+    fun cancel-scope(scope-id)
+      if scope-id == cid then
+        async-iox(on-cancel-hook)
+      else
+        // pass it along, it's presumably a child scope
+        // nested under this uncancelable one
+        cancel-scope(scope-id)
+
+    fun async-iox(f) async-iox(f)
+    fun discontinue() discontinue()
+
+  with mask behind<async>
+  action()
+
+// defer cancelation of the child-scoped `action` until the end of `action`. Note that
+// cancelation cannot be ignored, only deferred.
+pub fun defer-cancelation(action: () -> <asyncx|e> a): <asyncx|e> a
+  val canceled: ref<global,_> = ref(False)
+  fun on-cancel()
+    canceled := True
+  val result = unsafe-override-cancel(on-cancel, action)
+  if !canceled then
+    discontinue()
+  result
+
 
 // ----------------------------------------------------------------------------
 // Promises
@@ -56,7 +274,6 @@ pub alias async-exn = <async,exn>
 abstract struct promise<a>
   state : ref<global,promise-state<a>>
 
-
 abstract value type promise-state<a>
   Resolved( value : a )
   Awaiting( listeners : list<a -> io ()> )
@@ -68,11 +285,11 @@ pub fun promise() : async promise<a>
 // Await a promise; returns immediately if the promise was already resolved and otherwise
 // waits asynchronously.
 pub fun promise/await( p : promise<a> ) : asyncx a
-  fun setup(cb : _ -> io-noexn ())
+  fun setup(cb : _ -> io-noexn ()): io-noexn ()
     val r = p.state
     match (!r)
       Awaiting(listeners) -> r := Awaiting(Cons(cb,listeners))
-      Resolved(value) -> io-noexn1(cb,value) // resume right away; should not happen due to try-await
+      Resolved(value) -> cb(value) // resume right away; should not happen due to try-await
   match p.try-await
     Just(v) -> v
     Nothing -> await1(setup)
@@ -86,7 +303,7 @@ pub fun try-await( p : promise<a> ) : <async,ndet> maybe<a>
       _ -> Nothing
 
 // Resolve a promise to `value`. Raises an exception if the promise was already resolved.
-pub fun resolve( p : promise<a>, value : a ) : asyncx ()
+pub fun resolve( p : promise<a>, value : a ) : <asyncx,exn> ()
   async-io
     val r = p.state
     match !r
@@ -95,6 +312,10 @@ pub fun resolve( p : promise<a>, value : a ) : asyncx ()
         listeners.foreach fn(cbx)  // todo: through set-immediate?
           cbx(value) // set-immediate1( cbx, value )
       _ -> throw("Promise was already resolved")
+
+// Perform an I/O operation at the outer level; exceptions are propagated back.
+fun async-io( f : () -> io a ) : <asyncx,exn> a
+  async-io-noexn( { try(f) } ).untry
 
 // ----------------------------------------------------------------------------
 // Channels
@@ -130,12 +351,9 @@ pub fun channel() : async channel<a>
 
 // Receive (and remove) a value from the channel: returns immediately if a value is available and otherwise
 // waits asynchronously until a value becomes available.
-pub fun receive( ch : channel<a> ) : asyncx a
-  ch.receivex.untry
-
-fun receivex( ch : channel<a>, cancelable : bool = True ) : <async,ndet> error<a>
-  fun setup( cb : (_,_) -> io-noexn () )
-    fun cbr(x) cb(Ok(x),True)    
+fun receive( ch : channel<a>) : asyncx a
+  val setup: await-setup<_> = fn(cb : (_,_) -> io-noexn () )
+    fun cbr(x) cb(Result(x),True)
     val r = ch.state
     match !r
       Empty -> r := Waiting(cbr,[])
@@ -146,8 +364,8 @@ fun receivex( ch : channel<a>, cancelable : bool = True ) : <async,ndet> error<a
     Nothing
 
   match ch.try-receive
-    Just(v) -> Ok(v)
-    Nothing -> do-await(setup,empty-scope,cancelable)
+    Just(v) -> v
+    Nothing -> do-await(setup,async-scope).continue-await
 
 // Return immediately if a value is available on the channel and otherwise returns `Nothing`.
 pub fun try-receive( ch : channel<a> ) : <async,ndet> maybe<a>
@@ -169,8 +387,8 @@ fun emit-io( ch : channel<a>, value : a ) : io-noexn ()
       l(value)
 
 // Emit a value asynchronously into a channel.
-pub fun emit( ch : channel<a>, value : a ) : asyncx ()
-  async-io
+pub fun emit( ch : channel<a>, value : a ) : <asyncx> ()
+  async-io-noexn
     emit-io(ch,value)
 
 fun trace-channel( msg : string, ch : channel<a> ) : <async,ndet> ()
@@ -196,21 +414,27 @@ fun trace-anyx( s : string, x : a ) : async ()
 // `cancel` it (and return `Nothing`). Due to the generality of `cancel`, this `timeout`
 // abstraction can reliably time out over any composition of asynchronous operations
 // and is therefore quite expressive.
-
-pub fun timeout( secs : duration, action : () -> <asyncx|e> a, ?set-timeout: (unit-cb, int32) -> io-noexn any, ?clear-timeout: (any) -> io-noexn () ) : <asyncx|e> maybe<a>
+pub fun timeout( secs : duration, action : () -> <asyncx,io-noexn|e> a, ?set-timeout: (unit-cb, int32) -> io-noexn any, ?clear-timeout: (any) -> io-noexn () ) : <asyncx,io-noexn|e> maybe<a>
   firstof { duration/wait(secs); Nothing} { Just(action()) }
 
 // Execute `a` and `b` interleaved. As soon as one of them finishes,
 // `cancel` the other one and return the result of the first.
-pub fun firstof( a : () -> <async-exn|e> a, b : () -> <async-exn|e> a  ) : <async-exn|e> a  
-  cancelable 
-    val (ra,rb) = interleavedx { val x = mask behind<exn>{ a() }; cancel(); x }                              
-                               { val x = mask behind<exn>{ b() }; cancel(); x }   
-    match ra
-      Error(exn) | exn.is-cancel -> rb.untry
-      _          -> ra.untry    
-  
-  
+pub fun firstof( a : () -> <asyncx|e> a, b : () -> <asyncx|e> a) : <asyncx|e> a
+  fun runner(f)
+    fn(scope)
+      with finally { scope.cancel() } // cancel regardless of exn or result
+      mask<local> { f() }
+
+  // note: when we cancel `scope`, interleaved-raw returns Cancel items,
+  // rather than actually canceling the entire call
+  val results = interleaved-raw([runner(a), runner(b)])
+  val first = results.find-maybe fn(result)
+    match result
+      Result(x) -> Just(x)
+      Cancel -> Nothing
+  match first
+    Just(x) -> x
+    Nothing -> discontinue()
 
 // Wait (asynchronously) for `secs` seconds as a `:double`.
 // Use `yield()` to yield to other asynchronous operations.
@@ -223,7 +447,7 @@ pub fun duration/wait( secs : duration = zero, ?set-timeout: (unit-cb, int32) ->
   if secs <= zero then return yield()
   val msecs = max(zero:int32,secs.milli-seconds.int32)
   await fn(cb)
-    val tid = async/set-timeout( fn(){ cb(Ok(())) }, msecs )
+    val tid = async/set-timeout( fn(){ cb(()) }, msecs )
     Just( { async/clear-timeout(tid) } )
 
 // Yield to other asynchronous operations. Same as `wait(0)`.
@@ -250,59 +474,56 @@ fun async/clear-timeout( tid : timeout-id , ?clear-timeout: (any) -> io-noexn ()
 // Interleaved strands of execution
 // ----------------------------------------------------------------------------
 
+fun impossible(msg): total ()
+  unsafe-total
+    println("IMPOSSIBLE: " ++ msg)
+    exit(1)
+
 // Interleave two actions around their asynchronous operations.
-pub fun two/interleaved( action1 : () -> <async-exn|e> a, action2 : () -> <async-exn|e> b ) : <async-exn|e> (a,b)
-  val (ra,rb) = interleavedx( {mask behind<exn>(action1)}, {mask behind<exn>(action2)} )
-  [ra.maybe-exn,rb.maybe-exn].ordered_throw
-  (ra.untry,rb.untry)
+pub fun two/interleaved( action1 : () -> <asyncx,io-noexn|e> a, action2 : () -> <asyncx,io-noexn|e> b ) : <asyncx,io-noexn|e> (a,b)
+  fun act1() Left(action1())
+  fun act2() Right(action2())
+  match interleaved([act1, act2])
+    [Left(l), Right(r)] -> (l, r)
+    other -> impossible("two/interleaved returned " ++ other.length.show ++ " values")
 
-// Interleave a list of actions around their asynchronous operations.
-pub fun list/interleaved( xs : list<() -> <async-exn|e> a> ) : <async-exn|e> list<a>
-  val ress = xs.map( fn(f) { return { mask behind<exn>(f) } } ).interleavedx
-  //ress.map(maybe).ordered_throw
-  ress.map(untry)
+value struct interleaving<a>
+  incomplete: int
+  results: list<(int, strand-result<await-result<a>>)>
 
-fun maybe-exn( err : error<a> ) : maybe<exception>
-  match err
-    Error(exn) -> Just(exn)
-    _          -> Nothing
+fun interleaving/show(i: interleaving<_>)
+  "Interleaving(incomplete=" ++ i.incomplete.show ++ ", " ++ i.results.show ++ ")"
 
-fun ordered_throw( xs : list<maybe<exception>> ) : exn ()
-  var mexn := Nothing
-  xs.foreach fn(x)
-    match x
-      Nothing -> ()
-      Just(exn) -> match mexn
-        Nothing -> mexn := x
-        Just(exnx) ->
-          if ((exn.is-finalize && !exnx.is-finalize) || (exnx.is-cancel && !exn.is-cancel))
-            then mexn := x
-  match mexn
-    Just(exn)  -> rethrow(exn)
-    Nothing  -> ()
+pub fun list/interleaved(xs : list<() -> <asyncx,io-noexn|e> a> ) : <asyncx,io-noexn|e> list<a>
+  fun runner(f)
+    fn(_)
+      f()
+  xs.map(runner).interleaved-raw.map fn(result)
+    result.continue-await
 
-// Interleave two actions around their asynchronous operations and explicitly returning either
-// their result or their exception.
-pub fun interleavedx( action1 : () -> <async-exn|e> a, action2 : () -> <async-exn|e> b ) : <async|e> (error<a>,error<b>)
-  fun act1() Left(action1())  
-  fun act2() Right(action2())  
-  match interleavedx([act1,act2])  
-    Cons(x,Cons(y)) -> (x.unleft,y.unright)
-    _ ->
-      // this will never happen..
-      val exn = Exception("invalid interleaved result",ExnInternal("std/async/interleavedx(action1,action2)"))
-      (Error(exn),Error(exn))
+fun list/interleaved-raw(xs : list<(scope) -> <asyncx|e> a> ) : <asyncx|e> list<await-result<a>>
+  var state : some<a> interleaving<a> := Interleaving(xs.length, [])
+  with handler<strands<_>>
+    finally()
+      state.results.foreach fn(pair)
+        pair.snd.finalize-strand
 
-fun unleft( x : error<either<a,b>> ) : error<a>
-  match x
-    Ok(Left(l)) -> Ok(l)
-    Error(exn)  -> Error(exn)
-    _ -> Error(Exception("invalid left interleaved result",ExnInternal("std/async/interleavedx(action1,action2)")))
-fun unright( x : error<either<a,b>> ) : error<b>
-  match x
-    Ok(Right(r)) -> Ok(r)
-    Error(exn)     -> Error(exn)
-    _ -> Error(Exception("invalid right interleaved result",ExnInternal("std/async/interleavedx(action1,action2)")))
+    return(_)
+      // Treat finalized as cancels, since we're already returning await-result.
+      state.results.map fn(pair)
+        match pair.snd
+          Finalize(_) -> Cancel
+          Complete(x) -> x
+
+    fun strands-are-busy()
+      state.incomplete > 0
+
+    fun strand-done(idx,res)
+      state := Interleaving(state.incomplete - 1, state.results.insert(idx,res))
+
+  // with unsafe-pretend-stateless
+  with mask<local>
+  interleave-strands(xs)
 
 // Private effect to keep track of when a strand in an interleaving is done.
 // Preferred over using built-in state as this works well if there is an outer handler
@@ -311,8 +532,9 @@ fun unright( x : error<either<a,b>> ) : error<b>
 effect strands<a>
   // Are there still strands that need to be resumed?
   fun strands-are-busy() : bool
+
   // Call this when a strand is done.
-  fun strand-done(idx : int, result : error<a>) : ()
+  fun strand-done(idx : int, result : strand-result<await-result<a>>) : ()
 
 // Insert in order with an accumulating list.
 fun insert-acc( xs : list<(int,a)>, idx : int, value : a, acc : list<(int,a)> ) : list<(int,a)>
@@ -328,96 +550,119 @@ fun insert( xs : list<(int,a)>, idx : int, value : a, n : int  = 0 ) : list<(int
       Cons(x,xx) | x.fst < idx -> Cons(x, insert(xx, idx, value, n + 1))
       _ -> Cons((idx,value),xs)
 
-
-// Interleave a list actions around their asynchronous operations and explicitly returning either
-// either their result or their exception.
-pub fun list/interleavedx( xs : list<() -> <async-exn|e> a> ) : <async|e> list<error<a>>
-  val n = xs.length
-  if n==0 then []
-  elif n==1 then xs.map(unsafe-try-all)
-  else interleavedn(n,xs)
-
-fun interleavedn( n : int, xs : list<() -> <async-exn|e> a> ) : <async|e> list<error<a>> 
-  unsafe-no-ndet-div  
-    var cr : some<a> (int,list<(int,error<a>)>) := (n,[])
-    with handler 
-      return(x) 
-        cr.snd.map( snd )
-      fun strands-are-busy()   
-        cr.fst > 0    
-      fun strand-done(idx,res) 
-        cr := (cr.fst - 1, cr.snd.insert(idx,res)) 
-    mask<local>
-      interleaved-div(xs)  
-
-
 inline extern unsafe-no-ndet-div-cast : forall<a,e> (() -> <ndet,div|e> a) -> (() -> e a) 
   inline "#1" 
 
 fun unsafe-no-ndet-div( action : () -> <ndet,div|e> a ) : e a 
   unsafe-no-ndet-div-cast(action)()
 
-inline extern inject-effects : forall<a,h,e> (() -> e a) -> total (() -> <strands<a>,ndet,div|e> a)   
+inline extern inject-effects : forall<a,h,e> (() -> e a) -> total (() -> <strands<a>|e> a)
   inline "#1"
 
-fun error/is-finalize( t : error<a> ) : bool
-  match t
-    Error(exn) -> exn.is-finalize
-    _ -> False
+// Warning: Cancelation should not be caught unless you're carefully maintaining
+// cancelation semantics yourself.
+pub fun unsafe-catch-cancel(a: () -> <async|e> a): <async|e> await-result<a>
+  handle({ mask behind<async>(a) })
+    final ctl discontinue()
+      Cancel
+    return(x)
+      Result(x)
 
-fun error/is-cancel( t : error<a> ) : bool
-  match t
-    Error(exn) -> exn.is-cancel
-    _ -> False
+    // passthrough others
+    val async-scope = async-scope
+    fun do-await(setup, scope) do-await(setup,scope)
+    fun no-await(setup, scope, f) no-await(setup,scope, f)
+    fun async-iox(x) async-iox(x)
+    fun cancel-scope(scope) cancel-scope(scope)
 
-fun interleaved-div( xs : list<() -> <async-exn|e> a> ) : <async,ndet,div,strands<a>|e> ()
-  val strands =  xs.map-indexed fn(i,action)
-      return fn()
-        val res = unsafe-try-all(inject-effects(action))
-        strand-done(i,res)
-        if res.is-finalize then cancel()  // cancel others if finalization happens
+// fun unsafe-pretend-stateless(a: () -> <st<global>|e> a): e a
+//   unsafe-total(a)
+
+// fun mask-global-state(a: () -> e a): <st<global>|e> a
+//   with mask<read<global>>
+//   with mask<write<global>>
+//   with mask<alloc<global>>
+//   a()
+
+// TODO is there a better way to inform the caller of scope than having every item in the list accept it?
+fun interleave-strands(xs : list<(scope) -> <asyncx|e> a> ) : <asyncx,strands<a>|e> ()
+  val inner-scope: ref<global,_> = ref(Nothing)
+  val keep-spawning: ref<global,_> = ref(True)
   val ch : some<a,e> channel<() -> <async|e> a> = channel()
-  val handle-strand = handler
-    raw ctl do-await(setup,scope,c)
-      no-await( setup, scope, c) fn(res)
-        // emit a resumption of this strand into the channel
-        ch.emit-io( /* no-cps */ { rcontext.resume(res) }  )
-      ()  // stop the strand at this point      
-    // redirect all other operations
-    fun no-await(setup,scope,c,f)  
-      no-await(setup,scope,c,f)    
-    fun async-iox(f)  
-      async-iox(f)    
-    fun cancel(scope)  
-      cancel(scope)
+  
+  // interleave has custom cancelation handling. When the scope
+  // is canceled, we don't discontinue() but instead
+  // perform explicit cancelation of the child scope, and
+  // let that flow through into registering all outstanding scopes
+  // with a `Cancel` result.
+  with unsafe-override-cancel {
+    // Note we can't cancel() directly in this hook because cancel is async,
+    // but we can add it to the queue of actions to run
+    keep-spawning := False
+    ch.emit-io
+      (!inner-scope).foreach(cancel-scope)
+  }
 
-  strands.foreach fn(strand)
-    handle-strand{ mask behind<async>(strand) }
+  val sentinel-scope = async-scope
 
+  child-scope-without-auto-cancel fn(cid) // introduce a child scope which doesn't cancel-on-finalize
+    inner-scope.set(Just(cid))
+    fun yield-on-await(action)
+      (handler<async> {
+        raw ctl do-await(setup,scope)
+          // turn awaits into no-awaits, allowing other strands to execute
+          val unique-id = unsafe-total(unique)
+          no-await(setup, scope) fn(res)
+            ch.emit-io({ rcontext.resume(res) })
+          ()
+
+        // passthrough others
+        val async-scope = async-scope
+        fun no-await(setup,scope,f) no-await(setup,scope,f)
+        fun async-iox(f) async-iox(f)
+        fun cancel-scope(scope) cancel-scope(scope)
+        fun discontinue() discontinue()
+      }) {
+        with mask behind<async>
+        action()
+      }
+
+    xs.foreach-indexed fn(i, action)
+      if !(!keep-spawning) then
+        // Finalization has occurred synchronously, don't
+        // keep spawning actions.
+        strand-done(i, Complete(Cancel))
+      else
+        with yield-on-await
+        val res = strand-exec(inject-effects { action(sentinel-scope) })
+        strand-done(i, res)
+        if res.is-finalize then
+          keep-spawning := False
+          cancel-scope(cid)
+      ()
+
+  // this runs outside of the `child-scope` (unaffected by `cancel-scope(cid)`)
   while { strands-are-busy() } // while there are resumptions on the strands..
-    // the only way receive can throw is through a cancelation -- but in that case
-    // we should not cancel but instead await all canceled strands; so keep listening on the channel.
-    match(ch.receivex(False))
-      Error(_exn) -> () // ignore cancelation on receive
-      Ok(strand-resume) -> strand-resume()
+    val strand-resume = ch.receive
+    strand-resume()
   ()
-
-
 
 // ----------------------------------------------------------------------------
 // Await wrappers
 // ----------------------------------------------------------------------------
 
 // Convenience function for awaiting a NodeJS style callback where the first argument is a possible exception.
-pub fun await-exn0( setup : (cb : (null<exception>) -> io-noexn () ) -> io maybe<() -> io-noexn ()> ) : asyncx ()
-  await fn(cb)
-    setup( fn(nexn) cb(nexn.unnull(())) )
+pub fun await-exn0( setup : (cb : (null<exception>) -> io-noexn () ) -> io-noexn maybe<() -> io-noexn ()> ) : async-exn ()
+  setup/await fn(cb)
+    setup( fn(nexn) cb(Result(nexn.unnull(()))) )
+  .continue-await.untry
 
 // Convenience function for awaiting a NodeJS style callback where the first argument is a possible exception
 // and the second argument the possible result value.
-pub fun await-exn1( setup : (cb : (null<exception>,a) -> io-noexn () ) -> io maybe<() -> io-noexn ()> ) : asyncx a
-  await fn(cb)
-    setup( fn(nexn,x) cb(nexn.unnull(x)) )  
+pub fun await-exn1( setup : (cb : (null<exception>,a) -> io-noexn () ) -> io-noexn maybe<() -> io-noexn ()> ) : async-exn a
+  setup/await fn(cb)
+    setup( fn(nexn,x) cb(Result(nexn.unnull(x))) )
+  .continue-await.untry
 
 fun unnull( nexn : null<exception>, x : a  ) : error<a>
   match nexn.maybe
@@ -425,200 +670,163 @@ fun unnull( nexn : null<exception>, x : a  ) : error<a>
     Just(exn) -> Error(exn)
 
 // Convenience function for awaiting a zero argument callback.
-pub fun await0( setup : (cb : () -> io-noexn () ) -> io () ) : asyncx ()
-  await fn(cb) 
-    setup( fn() cb(Ok(())) )
-    Nothing 
+pub fun await0( setup : (cb : () -> io-noexn () ) -> io-noexn () ) : asyncx ()
+  setup/await fn(cb)
+    setup( fn() cb(Result(())) )
+    Nothing
+  .continue-await
 
-// Convenience function for awaiting a single argument callback.
-pub fun await1( setup : (cb : (a) -> io-noexn () ) -> io () ) : asyncx a
-  await fn(cb) 
-    setup( fn(x) cb(Ok(x)) ) 
-    Nothing 
+// // Convenience function for awaiting a single argument callback.
+pub fun await1( setup : (cb : (a) -> io-noexn () ) -> io-noexn () ) : asyncx a
+  setup/await fn(cb)
+    setup( fn(x) cb(Result(x)) )
+    Nothing
+  .continue-await
 
-// Execute `setup` to set up an asynchronous callback with the host platform. Invoke `cb` as the callback:
-// it takes either an exception or a result `a`. Usually `setup` returns `Nothing` but you can return a `Just(cleanup)`
-// value where the `cleanup` functions is invoked on cancellation to dispose of any resources (see the implementation of `wait`).
-// The callback should be invoked exactly once -- when that happens `await` is resumed with the result using `untry`
-// either raise an exception or return the plain result.
-pub fun setup/await( setup : (cb : error<a> -> io-noexn () ) -> io maybe<() -> io-noexn ()> ) : asyncx a
-  await-exn(setup).untry
-
-
-
-
-// ----------------------------------------------------------------------------
-// Async effect
-// ----------------------------------------------------------------------------
-alias await-result<a> = error<a>
-alias await-setup<a> = (cb : (error<a>,bool) -> io-noexn ()) -> io-noexn (maybe<() -> io-noexn ()>)
-
-// Asynchronous operations have the `:async` effect.
-pub effect async
-  ctl do-await( setup : await-setup<a>, scope : scope, cancelable : bool ) : error<a>
-  ctl no-await( setup : await-setup<a>, scope : scope, cancelable : bool, f : error<a> -> io-noexn ()  ) : ()
-  ctl async-iox( action : () -> io-noexn a ) : a
-  ctl cancel( scope : scope ) : ()
-
-
-// The `cancel` operations cancels any outstanding asynchronous operation under the innermost
-// `cancelable` handler by returning the `Cancel` exception. The `cancel` operation itself returns normally
-// without raising a `Cancel` exception.
-pub fun noscope/cancel() : async ()
-  cancel(empty-scope)
 
 // Primitive: Execute `setup` to set up an asynchronous callback with the host platform. Invoke `cb` as the callback:
 // it takes either an exception or a result `a`. Usually `setup` returns `Nothing` but you can return a `Just(cleanup)`
 // value where the `cleanup` functions is invoked on cancellation to dispose of any resources (see the implementation of `wait`).
 // The callback should be invoked exactly once -- when that happens `await-exn` is resumed with the result.
-pub fun await-exn( setup : (cb : (error<a>) -> io-noexn ()) -> io (maybe<() -> io-noexn ()>) ) : async error<a>
-  do-await(fn(cb)
-    match (try{ setup(fn(res) cb(res,True) ) })
-      Ok(mcleanup) -> mcleanup
-      Error(exn) ->
-        cb(Error(exn),True)
-        Nothing
-  , empty-scope, True)
+pub fun setup/await( setup : (cb : (a) -> io-noexn ()) -> io-noexn (maybe<() -> io-noexn ()>) ) : asyncx a
+  val result = do-await(fn(cb) { setup(fn(res) cb(Result(res),True)) }, async-scope)
+  result.continue-await
 
-// Primitive: Execute `setup` to set up an asynchronous callback with the host platform. Invoke `cb` as the callback: it takes either
-// an exception or a result value, together with boolean parameter whether the callback is done.
-// The callback `cb` will eventually emit the result into the given channel `ch` after applying the transformation `f` to the result.\
-// Note: once you exit the `cancelable` scope where `await-to-channel` was called, the callback is invoked with a `Cancel` exception.
-// The channel should always be awaited within the same `cancelable` scope as the `await-to-channel` invokation.
-pub fun await-to-channel( setup : (cb : (error<a>,bool) -> io-noexn ()) -> io (maybe<() -> io-noexn ()>), ch : channel<b>, f : error<a> -> b  ) : async channel<b>
-  no-await(fn(cb)
-    match(try{setup(cb)})
-      Ok(mcleanup) -> mcleanup
-      Error(exn) ->
-        cb(Error(exn),True)
-        Nothing
-   , empty-scope,True, fn(res)
-    ch.emit-io( f(res) )
-  )
-  ch
+// // Primitive: Execute `setup` to set up an asynchronous callback with the host platform. Invoke `cb` as the callback: it takes either
+// // an exception or a result value, together with boolean parameter whether the callback is done.
+// // The callback `cb` will eventually emit the result into the given channel `ch` after applying the transformation `f` to the result.\
+// // Note: once you exit the `child-scope` scope where `await-to-channel` was called, the callback is invoked with a `Cancel` exception.
+// // The channel should always be awaited within the same `child-scope` scope as the `await-to-channel` invokation.
+// pub fun await-to-channel( setup : (cb : (a,bool) -> io-noexn ()) -> io-noexn (maybe<() -> io-noexn ()>), ch : channel<b>, f : a -> b) : async channel<b>
+//   fun wrapped-setup(cb: (await-result<_>,bool) -> io-noexn ())
+//     setup fn (value, b)
+//       cb(Result(value), b)
+
+//   no-await(wrapped-setup, async-scope) fn(res)
+//     ch.emit-io(f(res.continue-await))
+//   ch
 
 fun async-io-noexn( f : () -> io-noexn a ) : <async,ndet> a
   async-iox(f)
 
-// Perform an I/O operation at the outer level; exceptions are propagated back.
-fun async-io( f : () -> io a ) : asyncx a
-  async-io-noexn( { try(f) } ).untry
+// // ----------------------------------------------------------------------------
+// // Async handlers: child-scope
+// // ----------------------------------------------------------------------------
 
-
-// ----------------------------------------------------------------------------
-// Async handlers: cancelable
-// ----------------------------------------------------------------------------
-
-inline extern interject-async( action : () -> <async|e> a) : total ( () -> <async,async|e> a)
-  inline "#1"
-
-// Execute `action` in a cancelable scope. If `cancel` is called within `action`,
-// any outstanding asynchronous operations started in the cancelable scope are canceled.
-// (Outstanding operations outside the cancelable scope are not canceled).
-pub fun cancelable( action : () -> <async|e> a ) : <async|e> a 
-  val cid = async-iox{ unique() }
-  fun extend(scope : scope )
-    parent-scope(cid,scope)
-
-  handle ({mask behind<async>(action)})
-    return(x) ->
+// Execute `action` in a child-scope scope. Once `action` is complete
+// (successfully or otherwise), all outstanding actions
+// within this scope are canceled.
+pub fun child-scope( action : () -> <async|e> a ) : <async|e> a
+  child-scope-without-auto-cancel fn(cid)
+    with finally
       // cancel any outstanding operations still in our scope.
       // this might be needed for `no-await` operations.
-      cancel(empty-scope.extend)
-      x
-    fun do-await(setup,scope,c)  -> do-await(setup,scope.extend,c)
-    fun no-await(setup,scope,c,f)  -> no-await(setup,scope.extend,c,f)
-    fun cancel(scope)  -> cancel(scope.extend)
-    fun async-iox(f)  -> async-iox(f)
+      cancel-scope(cid)
+    action()
 
-// ----------------------------------------------------------------------------
-// Async handle
-// ----------------------------------------------------------------------------
+// like child-scope, but the caller is responsible
+// for canceling the created scope
+fun child-scope-without-auto-cancel(action : (int) -> <async|e> a ) : <async|e> a
+  val cid = async-iox{ unique() }
+  handle ({mask behind<async> { action(cid) }})
+    val async-scope = async-scope.child(cid)
+    fun do-await(setup,scope) do-await(setup,scope)
+    fun no-await(setup,scope,f) no-await(setup,scope,f)
+    fun cancel-scope(scope) cancel-scope(scope)
+    fun async-iox(f) async-iox(f)
+    fun discontinue() discontinue()
+
+
+// // ----------------------------------------------------------------------------
+// // Async handle
+// // ----------------------------------------------------------------------------
 
 pub fun @default-async(action)
   async/handle(action)
 
-fun nodispose() : io-noexn () 
+fun noop(): ()
    ()
 
 // The outer `:async` effect handler. This is automatically applied by the compiler
 // around the `main` function if it has an `:async` effect.
-pub fun async/handle(action : () -> <async,io-noexn> () ) : io-noexn ()
-  val callbacks : ref<global,list<(scope,() -> io-noexn ())>> = unsafe-total{ref([])}
-  fun handle-await( setup : await-setup<a>, scope : scope, f : error<a> -> io-noexn (), cancelable : bool) : io-noexn ()
-    val cscope = child-scope(unique(),scope)
-    val dispose = ref(nodispose)
-    fun cb( res : error<_>, is-done : bool ) : io-noexn ()
-      if ((!callbacks).contains(cscope)) then
-        if is-done then
-          callbacks := (!callbacks).remove(cscope)
-          if res.is-error then try(!dispose).default(())
-        f(res)
+pub fun async/handle(action : () -> <async,io-noexn> a ) : io-noexn ()
+  val cancel-functions : ref<global,list<(scope,() -> <io-noexn|_> ())>> = unsafe-total{ref([])}
+  fun handle-await( setup : await-setup<a>, scope : scope, f : await-result<a> -> io-noexn ()) : io-noexn ()
+    // Each callback gets its own scope so we can tell when a given
+    // callback can be removed from `cancel-functions`
+    val cscope = scope.child(unique())
+    
+    // `cancel-hook` is the event-system action which should happen
+    // on cancellation, e.g. clearTimeout(...)
+    val cancel-hook = ref(noop)
 
-    // trace("register: " + cscope.show)
-    callbacks := Cons((cscope, if cancelable then fn(){ cb(Error(Exception("cancel",Cancel)),True) } else nodispose), !callbacks)
-    try {
-      // setup the callback which returns a possible dispose function
-      match(setup(cb))
-        Just(d) -> dispose := d
-        Nothing -> ()
-    } fn(exn)
-      // if setup fails, immediately resume with the exception
-      cb(Error(exn),True)
+    // TODO is there any code path where is-done is False?
+    fun cb( res : await-result<_>, is-done : bool ): io-noexn ()
+      fun cleanup()
+        if is-done && ((!cancel-functions).contains(cscope)) then
+          cancel-functions := (!cancel-functions).remove(cscope)
+          if res.is-cancel then
+            (!cancel-hook)()
+      cleanup()
+      f(res)
 
-  fun handle-cancel( scope : scope ) : io-noexn ()
-    (!callbacks).foreach fn(entry)
-      val (cscope,cb) = entry
-      if (cscope.in-scope-of(scope)) then cb()
+    val trigger-cancel: () -> io-noexn () = fn() cb(Cancel, True)
+    cancel-functions := Cons((cscope, trigger-cancel), !cancel-functions)
+    match(setup(cb))
+      Just(d) -> cancel-hook := d
+      Nothing -> ()
 
-  handle(action)
-    raw ctl do-await( setup, scope, c ) 
-      handle-await(setup,scope, fn(x) rcontext.resume(x), c)   // returns to outer event loop
-    fun no-await( setup, scope, c, f ) 
-      handle-await(setup,scope,f,c) 
-    fun cancel( scope ) 
+  fun handle-cancel( scope-id) : io-noexn ()
+    // TODO what happens if we try to cancel more than once?
+    (!cancel-functions).foreach fn(entry)
+      val (scope,trigger-cancel) = entry
+      if (scope.is-in-scope(scope-id)) then
+        trigger-cancel()
+
+  with handler<async>
+    val async-scope = empty-scope
+    raw ctl do-await(setup, scope)
+      handle-await(setup, scope, fn(x) { rcontext.resume(x); () })
+    fun no-await(setup, scope, f)
+      handle-await(setup, scope, f)
+    fun cancel-scope(scope)
       handle-cancel(scope)
-    fun async-iox( f ) 
+    final ctl discontinue()
+      impossible("discontinue occurred at the toplevel scope")
+
+    fun async-iox( f )
       f()
 
-fun io-noexn( f : () -> io-noexn a ) : io a
-  f()
-
-fun io-noexn1( f : (a1) -> io-noexn a, x1 : a1 ) : io a
-  f(x1)
+  action()
+  ()
 
 // ----------------------------------------------------------------------------
 // Scope identifiers
 // ----------------------------------------------------------------------------
 
-abstract struct scope( : list<int> )
+// A scope has an ID, plus a list of child IDs.
+// Every created scope has a unique ID
+alias scope-id = int
+abstract value struct scope( : list<scope-id> )
 
+// A scope is the chain starting with the current scope, including parent scopes up to the root scope ID
+// A scope is "in" a given scope-id if that scope-id appears in its id list
 val empty-scope = Scope([])
 
-fun parent-scope( cid : int, scope : scope ) : scope
-  match scope
-    Scope(cids) -> Scope(Cons(cid,cids))
-
-fun child-scope( id : int, scope : scope ) : scope
-  match scope
-    Scope(cids) -> Scope(cids ++ [id])
-
-fun ids/in-scope-of( child : list<int>, parent : list<int> ) : bool
+fun child(parent : scope, child-id: scope-id) : scope
   match parent
-    Nil -> True
-    Cons(p,ps) -> match child
-      Cons(c,cs) -> (c == p && in-scope-of(cs,ps))
-      Nil -> False
+    Scope(ids) -> Scope(Cons(child-id, ids))
 
-fun in-scope-of( child : scope, parent : scope ) : bool
-  match parent
-    Scope(pids) -> match child
-      Scope(cids) -> in-scope-of(cids,pids)
+fun is-in-scope(child : scope, parent : scope-id ) : bool
+  match child
+    Scope(ids) -> ids.find(fn(x) x == parent).is-just
 
-fun scope/(==)(scope1 : scope, scope2 : scope ) : bool
+// every scope with the same ID must implicitly contain the same
+// parent chain, so a simple comparison on the head is sufficient
+pub fun scope/(==)(scope1 : scope, scope2 : scope ) : bool
   match scope1
     Scope(ids1) -> match scope2
-      Scope(ids2) -> ids1==ids2
+      Scope(ids2) -> maybe/(==)(ids1.head, ids2.head, ?(==) = int/(==))
 
 // Convenience functions for scope maps
 fun remove( xs : list<(scope,a)>, scope : scope ) : list<(scope,a)>
@@ -630,35 +838,25 @@ fun lookup( xs : list<(scope,a)>, scope : scope ) : maybe<a>
 fun contains( xs : list<(scope,a)>, scope : scope ) : bool
   xs.lookup(scope).bool
 
-fun show( s : scope ) : string
+pub fun scope/show( s : scope ) : string
   match s
-    Scope(ids) -> ids.map(show).join("-")
+    Scope(ids) -> " " ++ ids.map(fn(id) "{" ++ id.show ++ "}").join("<") ++ "<"
 
+// TODO make private?
+pub fun scope/cancel(s: scope)
+  match s
+    // TODO: this matches even an empty scope!
+    // https://github.com/koka-lang/koka/issues/730
+    Scope(ids) ->
+      match ids
+        Cons(scope-id, _) -> cancel-scope(scope-id)
 
+        // TODO: make it impossible by types to have an empty scope?
+        _ -> ()
 
-abstract extend type exception-info
-  con Cancel
-  con Finalize(yld:yield-info)
-
-// Was this a cancelation exception?
-fun exn/is-cancel( exn : exception ) : bool
-  match exn.info
-    Cancel -> True
-    _      -> False
-
-// Was this a finalization exception?
-fun exn/is-finalize(exn : exception) : bool
-  match exn.info
-    Finalize -> True
-    _ -> False
-
-fun unsafe-try-all( action : () -> <exn|e> a ) : e error<a>
-  val fin = unsafe-try-finalize{ try(action) } 
-  match fin
-    Right(t)  -> t
-    Left(yld)  -> Error(Exception("finalize",Finalize(yld)))
-
-fun rethrow( exn : exception ) : exn a
-  match exn.info
-    Finalize(yld) -> unsafe-reyield(yld)
-    _             -> throw-exn(exn)
+// execute an action, but observe whether it completed normally or
+// needs to instead run a finalizer (due to cancellation, exception, etc)
+fun strand-exec( action : () -> <async|e> a ): <async|e> strand-result<await-result<a>>
+  match unsafe-try-finalize({ unsafe-catch-cancel(action) })
+    Left(fin) -> Finalize(fin)
+    Right(v) -> Complete(v)

--- a/test/async/async-test.kk
+++ b/test/async/async-test.kk
@@ -1,0 +1,362 @@
+import std/test
+import std/num/int32
+import std/num/int64
+import std/async/async
+import std/async/timer
+import std/time/duration
+import std/core-extras
+import std/core/unsafe
+
+// workaround for https://github.com/koka-community/std/issues/30
+fun list/expect(x: list<a>, f: () -> <exn,expect|e> list<a>, ?(==): (a, a) -> bool, ?show: (a) -> string): <expect|e> ()
+  test/expect(x, f, ?(==)=list/(==))
+fun maybe/expect(x: maybe<a>, f: () -> <exn,expect|e> maybe<a>, ?(==): (a, a) -> bool, ?show: (a) -> string): <expect|e> ()
+  test/expect(x, f, ?(==)=maybe/(==))
+
+fun list/push(l, item)
+  l ++ [item]
+
+fun listref/push(lr: ref<_, list<a>>, item: a, ?show: (a) -> string)
+  // println("PUSH: " ++ item.show)
+  lr.modify fn(l)
+    l := l.push(item)
+
+val short-pause = 1.milli-seconds
+val long-pause = 100.milli-seconds
+
+// rbset doesn't have remove, and hashset doesn't work in JS
+fun listset/add(l: list<v>, v: v, ?(==): (v, v) -> bool): list<v>
+  if l.find(fn(i) i == v).is-just then l
+  else Cons(v,l)
+
+fun listset/remove(l: list<v>, v: v, ?(==): (v, v) -> bool): list<v>
+  l.list/remove(fn(i) i == v)
+
+fun noleaks(action: () -> <async,io|e> ()): <async,io|e> ()
+  val pending: ref<global,list<(int, async/scope)>> = ref([])
+
+  fun register(api, scope: async/scope)
+    val id = unique()
+    val entry = (id, scope)
+    // println("[track-leaks " ++ api ++ "] -> [" ++ entry.show ++ "]")
+
+    pending := (!pending).add(entry)
+    fun done(result)
+      // unsafe-total
+      //   println("[track-leaks " ++ api ++ "] <- [" ++ entry.show ++ "] cancel=" ++ result.is-cancel.show)
+      pending := (!pending).remove(entry)
+    done
+
+  with handler<async>
+    fun do-await(setup, scope)
+      val done = register("do-await", scope)
+      val result = do-await(setup, scope)
+      done(result)
+      result
+
+    fun no-await(setup,scope,f)
+      val done = register("no-await", scope)
+      no-await(setup, scope) fn(result)
+        done(result)
+        f(result)
+
+    fun async-iox(f)
+      async-iox(f)
+
+    fun cancel-scope(scope)
+      cancel-scope(scope)
+
+    val async-scope = async-scope
+    fun discontinue() discontinue()
+
+  with mask behind<async>
+  with finally
+    if ! (!pending).is-empty then
+      // println("[track-leaks] pending=" ++ (!pending).map(fst).show)
+      throw("Test leaked " ++ (!pending).length.show ++ " async callbacks")
+  action()
+
+effect audit<a>
+  fun record(value: a): ()
+  fun records(): list<a>
+
+// fun audit(action: () -> <audit<a>,expect,div|e> b, ?show: (a) -> div string): <div,expect|e> b
+fun audit(action: () -> <audit<a>,expect,div,console|e> b, ?show: (a) -> div string): <div,console,expect|e> b
+  var log := []
+  handle(action)
+    fun record(value)
+      // TODO `hint` instead of println
+      // println("record: " ++ value.show)
+      log := log.push(value)
+      ()
+    fun records() -> log
+
+fun error-message(err: error<_>): maybe<string>
+  match err
+    Error(ex) -> Just(ex.message)
+    Ok(_) -> Nothing
+
+fun noleak-test(name, body, ?kk-module, ?kk-line)
+  // effectful-test("[vanilla] " ++ name, body) // rule out interference by noleaks itself
+  effectful-test(name) { noleaks(body) }
+
+
+effect flip
+  ctl flip(): bool
+
+fun both(f: () -> <flip|e> a): e list<a>
+  handle(f)
+    return(x) [x]
+    ctl flip()
+      resume(False) ++ resume(True)
+
+fun main(): <io-noexn,async> ()
+  run-tests
+    group("noleaks")
+      effectful-test("fails if a block leaks a callback")
+        val result = try
+          with noleaks
+          no-await(fn (cb) { Nothing }, async-scope, fn(_) {})
+        expect(Just("Test leaked 1 async callbacks")) { result.error-message }
+
+      effectful-test("doesn't interfere with async execution")
+        val result = try
+          with noleaks
+          wait(short-pause)
+          throw("fail!")
+        expect(Just("fail!")) { result.error-message }
+
+    noleak-test("simple sleep")
+      expect(123)
+        wait(short-pause)
+        123
+
+    noleak-test("interleaved singleton")
+      expect([1])
+        fun action()
+          wait(short-pause)
+          1
+        interleaved([action])
+
+    noleak-test("interleaved singleton which throws")
+      with audit
+      fun action()
+        with finally
+          record("finally")
+        wait(short-pause)
+        throw("error")
+
+      expect(Just("error"))
+        try { interleaved([action]) }.error-message
+
+      expect(["finally"]) { records() }
+
+    noleak-test("interleaved pair")
+      val pair =
+        interleaved {
+          wait(short-pause)
+          1
+        } {
+          wait(short-pause)
+          2
+        }
+      expect((1,2)) { pair }
+
+    noleak-test("cancel the scope above an interleave")
+      with audit
+      val result = unsafe-catch-cancel
+        with child-scope
+        val outer-scope = async-scope
+        interleaved {
+          wait(short-pause)
+          outer-scope.cancel()
+        } {
+          with finally
+            record("finally")
+            wait(long-pause)
+          "strand 2 complete"
+        }
+      expect(["finally"]) { records() }
+      expect(True) { result.is-cancel }
+
+    noleak-test("firstof doesn't run more actions if the first is synchronous")
+      with audit
+      val result = firstof {
+        1
+      } {
+        wait(short-pause)
+        record("second branch executed")
+        2
+      }
+      expect(result) { 1 }
+      expect([]: list<string>) { records() }
+
+    noleak-test("firstof doesn't spawn further actions if the first raises synchronously")
+      with audit
+      val result = try
+        firstof {
+          throw("branch 1")
+        } {
+          wait(short-pause)
+          record("second branch executed")
+        }
+      expect(Just("branch 1")) { result.error-message }
+      expect([]: list<string>) { records() }
+
+    noleak-test("interleave doesn't spawn further actions if the first raises synchronously")
+      with audit
+      val result = try
+        interleaved([{
+          throw("branch 1")
+        }, {
+          wait(short-pause)
+          record("second branch executed")
+        }])
+      expect(Just("branch 1")) { result.error-message }
+      expect([]: list<string>) { records() }
+
+    noleak-test("interleave with finalization after exn")
+      with audit
+      val result = try
+        interleaved {
+          wait(short-pause)
+          throw("strand 1 failed")
+        } {
+          with finally
+            record("finally")
+          on-cancel {
+            record("cancel")
+          } {
+            wait(long-pause)
+          }
+          "strand 2 complete"
+        }
+      expect(["cancel", "finally"]) { records() }
+      expect(Just("strand 1 failed")) { result.error-message }
+
+
+    noleak-test("firstof with finalization in slower branch")
+      with audit
+      val result = firstof {
+        wait(short-pause)
+        1
+      } {
+        with finally
+          record("finally")
+        on-cancel {
+          record("cancel")
+        } {
+          wait(long-pause)
+        }
+        2
+      }
+      expect(["cancel", "finally"]) { records() }
+      expect(1) { result }
+
+    noleak-test("finalization can be async")
+      val log = ref([]: list<string>)
+      fun long-running()
+        fun cleanup()
+          wait(long-pause)
+          log.push("cleanup")
+        
+        with finally(cleanup)
+        log.push("start")
+        wait(long-pause) // <- will be canceled
+        log.push("wakeup")
+        "long"
+
+      fun short-running()
+        wait(short-pause)
+        log.push("cancel")
+        "short"
+
+      val result = firstof(long-running, short-running)
+      log.push("result: " ++ result)
+      val e = list/(==)(["a"], ["b"])
+      expect(["start", "cancel", "cleanup", "result: short"]) { !log }
+
+    noleak-test("cancellation and try")
+      with audit
+      fun interruptible()
+        with finally { record("finally") }
+        try {
+          record("start")
+          wait(long-pause)
+        } fn(e) {
+          record("catch")
+        }
+        record("after-catch")
+        wait(short-pause)
+        record("still running...")
+        "result"
+
+      expect(Nothing: maybe<string>)
+        timeout(short-pause, interruptible)
+
+      expect(["start", "finally"]) { records() }
+
+    noleak-test("error in cancelation is raised")
+      fun interruptible()
+        with finally { throw("finalization exn") }
+        wait(long-pause)
+        "result"
+
+      expect("finalization exn")
+        try {
+          timeout(short-pause, interruptible)
+          "success"
+        } fn(e) { e.message }
+
+    noleak-test("exception in main code takes priority over error in cancelation")
+      fun interruptible()
+        with finally { throw("finalization exn") }
+        wait(long-pause)
+        "main exn"
+
+      expect("finalization exn")
+        try {
+          firstof(interruptible)
+            wait(short-pause)
+            throw("main exn")
+          "success"
+        } fn(e) { e.message }
+
+    noleak-test("defer-cancelation defers cancelation signal until block is complete")
+      val log = ref([]: list<string>)
+      fun interruptible()
+        defer-cancelation
+          wait(long-pause)
+          log.push("in critical section")
+        log.push("after critical section")
+
+      expect(Nothing) { timeout(short-pause, interruptible) }
+      expect(["in critical section"]) { !log }
+
+    noleak-test("a cancelable block within a defered-cancelation block is canceled immediately")
+      with audit
+      fun interruptible()
+        defer-cancelation()
+          fun inner()
+            on-cancel { record("inner canceled") }
+              wait(long-pause)
+            record("inner still running after cancel")
+          timeout(short-pause, inner)
+          record("after-inner")
+        record("after-defer")
+      timeout(short-pause, interruptible)
+      expect(["inner canceled", "after-inner"]) { records() }
+
+    // noleak-test("multiple resumption works within async")
+    //   with audit
+    //   val result = both
+    //     wait(short-pause)
+    //     if flip() then
+    //       wait(short-pause)
+    //       record(True)
+    //       "heads"
+    //     else
+    //       record(False)
+    //       "tails"
+    //   expect([True, False]) { records() }
+    //   expect(["heads", "tails"]) { result }


### PR DESCRIPTION
This is a big one, I'm happy to walk through the module face-to-face sometime if you'd like.

Essentially, `cancel` should not be an exception for a couple of minor reasons:
- it's too easy to accidentally catch it, a `try` will discard a cancelation signal and the code may carry on as a leaked strand
- it means all async code can also throw other exceptions, you can't see from the types whether it throws a "real" exception

But also one big reason: it should be possible to _defer_ cancelation. This allows code to implement "critical sections" where they won't get canceled. You don't need this for exceptions because your critical section should be written carefully not to throw exceptions, but it's not possible to write uncancelable code (unless you forbid yielding, which isn't practical).

The existing code allowed this via individual callbacks (using `cancelable=False`), but using that requires dealing with callbacks. Now you can wrap an arbitrary `async` expression in `defer-cancelation` and know that the block won't be interrupted in the middle, cancelation will be delayed until after the block has completed.

There's precedence for these cancelation semantics, the one I'm most familiar with is [cats-effect](https://typelevel.org/cats-effect/docs/typeclasses/monadcancel), there's an [interesting thread here](https://github.com/typelevel/cats-effect/discussions/1979) going over the rationale for this model.

I've added fairly extensive tests so I'm fairly confident in the new semantics 🤞. And I've added comments to explain the reasoning of why things are structured in a certain way, thus the rather high line-count.

There's one outstanding issue I haven't been able to solve, which is that `asyncx` should _not_ include `st<global>`. I mentioned this in discord, but I haven't been able to make a more minimal reproduction yet to demonstrate the issue.